### PR TITLE
converting functions to return site list if requested

### DIFF
--- a/R/brazil.R
+++ b/R/brazil.R
@@ -9,6 +9,8 @@
 #'   YYYY-MM-DD. Default is 1900-01-01.
 #' @param end_date Character. End date with format YYYY-MM-DD.
 #'   Default is the current date.
+#' @param sites Logical. If TRUE, returns a list of measurement
+#'   sites.
 #' @param ... Additional arguments. None implemented.
 #'
 #' @return data frame of discharge time-series
@@ -22,7 +24,12 @@ brazil <- function(site,
                    variable = "discharge",
                    start_date = NULL,
                    end_date = NULL,
+                   sites = FALSE,
                    ...) {
+
+  if (sites) {
+    return(brazil_sites)
+  }
 
   if (is.null(start_date))
     start_date <- "1900-01-01"

--- a/R/canada.R
+++ b/R/canada.R
@@ -9,6 +9,8 @@
 #'   YYYY-MM-DD. Default is 1900-01-01.
 #' @param end_date Character. End date with format YYYY-MM-DD.
 #'   Default is the current date.
+#' @param sites Logical. If TRUE, returns a list of measurement
+#'   sites.
 #' @param ... Additional arguments. None implemented.
 #'
 #' @return data frame of discharge time-series
@@ -22,7 +24,12 @@ canada <- function(site,
                    variable = "discharge",
                    start_date = NULL,
                    end_date = NULL,
+                   sites = FALSE,
                    ...) {
+
+  if (sites) {
+    return(canada_sites)
+  }
 
   if (is.null(start_date))
     start_date <- "1900-01-01"

--- a/R/chile.R
+++ b/R/chile.R
@@ -15,6 +15,8 @@ ending <- "%22],%22start%22:null,%22end%22:null},%22export%22:{%22map%22:%22Shap
 #'   YYYY-MM-DD. Default is 1900-01-01.
 #' @param end_date Character. End date with format YYYY-MM-DD.
 #'   Default is the current date.
+#' @param sites Logical. If TRUE, returns a list of measurement
+#'   sites.
 #' @param ... Additional arguments. None implemented.
 #'
 #' @return data frame of discharge time-series
@@ -28,7 +30,12 @@ chile <- function(site,
                   variable = "discharge",
                   start_date = NULL,
                   end_date = NULL,
+                  sites = FALSE,
                   ...) {
+
+  if (sites) {
+    return(chile_sites)
+  }
 
   if (variable == "stage") {
     stop("Stage data is not currently available for Chile")
@@ -47,12 +54,13 @@ chile <- function(site,
   Sys.sleep(.25)
   outpath <- tempfile()
   website <- paste0(original, site, ending)
-  file <- try(
-    html_session(website) %>% html_element('body') %>% html_text('url')
-  )
-  if (inherits(file, "try-error")) {
-    next
-  }
+  ## file <- try(
+  ##   html_session(website) %>% html_element('body') %>% html_text('url')
+  ## )
+  ## if (inherits(file, "try-error")) {
+  ##   stop()
+  ## }
+  file <- html_session(website) %>% html_element('body') %>% html_text('url')
   page <- gsub(".*https", "", file)
   page <- gsub("}}}", "", page)
   page <- paste0("https", page)

--- a/R/france.R
+++ b/R/france.R
@@ -9,6 +9,8 @@
 #'   YYYY-MM-DD. Default is 1900-01-01.
 #' @param end_date Character. End date with format YYYY-MM-DD.
 #'   Default is the current date.
+#' @param sites Logical. If TRUE, returns a list of measurement
+#'   sites.
 #' @param ... Additional arguments. None implemented.
 #'
 #' @return data frame of discharge time-series
@@ -22,7 +24,12 @@ france <- function(site,
                    variable = "discharge",
                    start_date = NULL,
                    end_date = NULL,
+                   sites = FALSE,
                    ...) {
+
+  if (sites) {
+    return(french_sites)
+  }
 
   if (variable == "stage") {
     stop("Stage data is not currently available for France")

--- a/R/japan.R
+++ b/R/japan.R
@@ -9,6 +9,8 @@
 #'   YYYY-MM-DD. Default is 1900-01-01.
 #' @param end_date Character. End date with format YYYY-MM-DD.
 #'   Default is the current date.
+#' @param sites Logical. If TRUE, returns a list of measurement
+#'   sites.
 #' @param ... Additional arguments. None implemented.
 #'
 #' @return data frame of discharge time-series
@@ -24,7 +26,12 @@ japan <- function(site,
                   variable = "discharge",
                   start_date = NULL,
                   end_date = NULL,
+                  sites = FALSE,
                   ...) {
+
+  if (sites) {
+    return(japan_sites)
+  }
 
   path <- "http://www1.river.go.jp/cgi-bin/DspWaterData.exe"
 
@@ -68,18 +75,22 @@ japan <- function(site,
       "&BGNDATE=", day,
       "&ENDDATE=", ending
     )
-    file <- try(
-      html_session(website) %>%
+    ## file <- try(
+    ##   html_session(website) %>%
+    ##   read_html() %>%
+    ##   html_element("body")
+    ## )
+    ## if (inherits(file, "try-error")) {
+    ##   next
+    ## }
+    ## file1 <- try(file %>% html_table())
+    ## if (inherits(file1, "try-error")) {
+    ##   next
+    ## }
+    file <- html_session(website) %>%
       read_html() %>%
       html_element("body")
-    )
-    if (inherits(file, "try-error")) {
-      next
-    }
-    file1 <- try(file %>% html_table())
-    if (inherits(file1, "try-error")) {
-      next
-    }
+    file1 <- file %>% html_table()
     ## Remove header
     df <- file1[5:nrow(file1), ]
     ## First column is the time

--- a/R/southAfrica.R
+++ b/R/southAfrica.R
@@ -18,6 +18,8 @@
 #'   available from the website. Otherwise if `primary=TRUE` then sub-daily
 #'   data for either `stage` or `discharge` will be returned. Note that the
 #'   primary data is an irregular time series.
+#' @param sites Logical. If TRUE, returns a list of measurement
+#'   sites.
 #' @param ... Additional arguments. None implemented.
 #'
 #' @return data frame of discharge time-series
@@ -37,7 +39,12 @@ southAfrica <- function(site,
                         start_date = NULL,
                         end_date = NULL,
                         primary = FALSE,
+                        sites = FALSE,
                         ...) {
+
+  if (sites) {
+    return(southAfrican_sites)
+  }
 
   ## TODO is it somehow possible to retrieve the start and end
   ## point of the data record?

--- a/R/uk.R
+++ b/R/uk.R
@@ -12,6 +12,8 @@ base_url <- "http://environment.data.gov.uk"
 #'   YYYY-MM-DD. Default is 1900-01-01.
 #' @param end_date Character. End date with format YYYY-MM-DD.
 #'   Default is the current date.
+#' @param sites Logical. If TRUE, returns a list of measurement
+#'   sites.
 #' @param ... Additional arguments. None implemented.
 #'
 #' @return data frame of discharge time-series
@@ -22,7 +24,16 @@ base_url <- "http://environment.data.gov.uk"
 #' plot(x$Date, x$Q, type='l')
 #' }
 #' @export
-uk <- function(site, variable, start_date = NULL, end_date = NULL, ...) {
+uk <- function(site,
+               variable,
+               start_date = NULL,
+               end_date = NULL,
+               sites = FALSE,
+               ...) {
+
+  if (sites) {
+    return(uk_sites)
+  }
 
   if (is.null(start_date))
     start_date <- as.Date("1900-01-01")

--- a/R/usa.R
+++ b/R/usa.R
@@ -9,6 +9,8 @@
 #'   YYYY-MM-DD. Default is 1900-01-01.
 #' @param end_date Character. End date with format YYYY-MM-DD.
 #'   Default is the current date.
+#' @param sites Logical. If TRUE, returns a list of measurement
+#'   sites.
 #' @param ... Additional arguments. None implemented.
 #'
 #' @return data frame of discharge time-series
@@ -22,7 +24,12 @@ usa <- function(site,
                 variable = "stage",
                 start_date = NULL,
                 end_date = NULL,
+                sites = FALSE,
                 ...) {
+
+  if (sites) {
+    return(usa_sites)
+  }
 
   if (is.null(start_date))
     start_date <- as.Date("1900-01-01")


### PR DESCRIPTION
This commit changes all functions to return sites if the user requests, e.g. by doing `australia(sites=TRUE)`. The default value of `sites` is FALSE. This address issue #10 